### PR TITLE
Bug fix: Orders could not be interacted with after creation.

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -10,18 +10,9 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
-    Table,
     Text,
 )
 from sqlalchemy.orm import relationship
-
-order_items = Table(
-    "order_items",
-    Base.metadata,
-    Column("order_id", ForeignKey("orders.id"), primary_key=True),
-    Column("menu_item_id", ForeignKey("menu_items.id"), primary_key=True),
-    Column("quantity", Integer),
-)
 
 
 class UserRole(str, enum.Enum):
@@ -62,16 +53,29 @@ class MenuItem(Base):
     category = Column(String)
     image_base64 = Column(Text)  # Base64-encoded images
 
+    order_items = relationship("OrderItem", back_populates="menu_item")
+
 
 class Order(Base):
     __tablename__ = "orders"
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"))
-    items = relationship("MenuItem", secondary=order_items)
     date_ordered = Column(DateTime, default=datetime.datetime.utcnow)
     status = Column(Enum(OrderStatus), default=OrderStatus.PENDING)
     delivery_address = Column(String)
     phone_number = Column(String)
 
     user = relationship("User", back_populates="orders")
+    items = relationship("OrderItem", back_populates="order")
+
+
+class OrderItem(Base):
+    __tablename__ = "order_items"
+
+    order_id = Column(Integer, ForeignKey("orders.id"), primary_key=True)
+    menu_item_id = Column(Integer, ForeignKey("menu_items.id"), primary_key=True)
+    quantity = Column(Integer)
+
+    order = relationship("Order", back_populates="items")
+    menu_item = relationship("MenuItem", back_populates="order_items")

--- a/app/db/schemas.py
+++ b/app/db/schemas.py
@@ -88,7 +88,7 @@ class OrderCreate(OrderBase):
 class Order(OrderBase):
     id: int
     user_id: int
-    items: List[MenuItem] = []
+    items: List[OrderItem] = []
 
     class Config:
         orm_mode = True

--- a/app/tests/modules/orders/test_orders_service.py
+++ b/app/tests/modules/orders/test_orders_service.py
@@ -1,4 +1,4 @@
-from db.models import MenuItem, Order
+from db.models import MenuItem, Order, OrderItem
 from fastapi import status
 
 
@@ -77,22 +77,48 @@ def test_create_order_unauthorised_returns_401(anon_client):
 
 
 def test_get_orders_returns_one_item_with_200(customer_client, test_db):
+    # Create a menu item to associate with the order
+    menu_item = MenuItem(
+        name="Special Pizza",
+        price=15.99,
+        category="Pizza",
+        description="A delicious pizza with a special blend of toppings",
+        image_base64="base64string"
+    )
+    test_db.add(menu_item)
+    test_db.commit()
+
+    # Create an order and add to the database
     order = Order(delivery_address="123 Main St", phone_number="555-1234", user_id=1)
     test_db.add(order)
     test_db.commit()
 
+    # Create an order item and add it to the order
+    order_item = OrderItem(
+        order_id=order.id,
+        menu_item_id=menu_item.id,
+        quantity=2
+    )
+    test_db.add(order_item)
+    test_db.commit()
+
+    # Make a GET request to fetch orders
     response = customer_client.get("/orders")
 
     assert response.status_code == status.HTTP_200_OK
     orders_response = response.json()
 
+    # Assertions for the response
     assert len(orders_response) == 1
     assert orders_response[0].get("id") == order.id
     assert orders_response[0].get("delivery_address") == "123 Main St"
     assert orders_response[0].get("phone_number") == "555-1234"
-    assert orders_response[0].get("items") == []
+    assert len(orders_response[0].get("items")) == 1  # Checking there is exactly one item in the order
+    assert orders_response[0].get("items")[0]["menu_item_id"] == menu_item.id
+    assert orders_response[0].get("items")[0]["quantity"] == 2
     assert orders_response[0].get("user_id") is not None
     assert orders_response[0].get("status") == "Pending"
+
 
 
 def test_get_orders_empty_returns_empty_list_with_200(customer_client):
@@ -112,21 +138,46 @@ def test_get_orders_unauthorised_returns_401(anon_client):
 
 
 def test_get_order_succesfully_returns_200(customer_client, test_db):
+    # Create a menu item to associate with the order
+    menu_item = MenuItem(
+        name="Deluxe Burger",
+        price=9.99,
+        category="Burgers",
+        description="A large burger with all toppings",
+        image_base64="base64string"
+    )
+    test_db.add(menu_item)
+    test_db.commit()
+
+    # Create an order and add to the database
     order = Order(delivery_address="123 Main St", phone_number="555-1234", user_id=1)
     test_db.add(order)
     test_db.commit()
 
+    # Create an order item and add it to the order
+    order_item = OrderItem(
+        order_id=order.id,
+        menu_item_id=menu_item.id,
+        quantity=1
+    )
+    test_db.add(order_item)
+    test_db.commit()
+
+    # Make a GET request to fetch the specific order
     response = customer_client.get(f"/orders/{order.id}")
 
     assert response.status_code == status.HTTP_200_OK
     order_response = response.json()
 
+    # Assertions for the response
     assert order_response.get("id") == order.id
     assert order_response.get("delivery_address") == "123 Main St"
     assert order_response.get("phone_number") == "555-1234"
-    assert order_response.get("items") == []
-    assert order_response.get("user_id") is not None
+    assert order_response.get("user_id") == 1
     assert order_response.get("status") == "Pending"
+    assert len(order_response.get("items")) == 1  # Ensure there is one item in the order
+    assert order_response.get("items")[0]["menu_item_id"] == menu_item.id
+    assert order_response.get("items")[0]["quantity"] == 1
 
 
 def test_get_order_unauthorised_returns_401(anon_client, test_db):
@@ -145,3 +196,80 @@ def test_get_order_not_exist_returns_404(customer_client):
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json().get("detail") == "Order not found"
+
+def test_create_order_with_multiple_items(customer_client, test_db):
+    # Create multiple menu items
+    item1 = MenuItem(name="Cheese Pizza", price=12.00, category="Pizza", description="Cheesy goodness", image_base64="")
+    item2 = MenuItem(name="Veggie Pizza", price=15.00, category="Pizza", description="Loaded with veggies", image_base64="")
+    test_db.add_all([item1, item2])
+    test_db.commit()
+
+    order_data = {
+        "delivery_address": "123 Pizza Street",
+        "phone_number": "555-6789",
+        "items": [
+            {"menu_item_id": item1.id, "quantity": 1},
+            {"menu_item_id": item2.id, "quantity": 1}
+        ]
+    }
+
+    response = customer_client.post("/orders", json=order_data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    response_json = response.json()
+    assert len(response_json.get("items")) == 2
+    assert response_json.get("delivery_address") == "123 Pizza Street"
+    assert response_json.get("phone_number") == "555-6789"
+
+
+def test_list_multiple_orders(customer_client, test_db):
+    # Create and add multiple orders with items
+    menu_item = MenuItem(name="Burger", price=8.99, description="A tasty burger", image_base64="")
+    test_db.add(menu_item)
+    test_db.commit()
+
+    order1 = Order(delivery_address="456 Main St", phone_number="555-2345", user_id=1)
+    order2 = Order(delivery_address="789 Side St", phone_number="555-5678", user_id=1)
+    test_db.add_all([order1, order2])
+    test_db.commit()
+
+    order_item1 = OrderItem(order_id=order1.id, menu_item_id=menu_item.id, quantity=2)
+    order_item2 = OrderItem(order_id=order2.id, menu_item_id=menu_item.id, quantity=3)
+    test_db.add_all([order_item1, order_item2])
+    test_db.commit()
+
+    response = customer_client.get("/orders")
+
+    assert response.status_code == status.HTTP_200_OK
+    response_json = response.json()
+    assert len(response_json) == 2
+    assert response_json[0]["delivery_address"] in ["456 Main St", "789 Side St"]
+    assert response_json[1]["delivery_address"] in ["456 Main St", "789 Side St"]
+
+
+def test_get_individual_orders(customer_client, test_db):
+    # Create and add multiple orders with items
+    menu_item = MenuItem(name="Sandwich", price=5.99, description="Delicious sandwich", image_base64="")
+    test_db.add(menu_item)
+    test_db.commit()
+
+    order1 = Order(delivery_address="321 New Ave", phone_number="555-4321", user_id=1)
+    order2 = Order(delivery_address="654 Old Ave", phone_number="555-8765", user_id=1)
+    test_db.add_all([order1, order2])
+    test_db.commit()
+
+    order_item1 = OrderItem(order_id=order1.id, menu_item_id=menu_item.id, quantity=1)
+    order_item2 = OrderItem(order_id=order2.id, menu_item_id=menu_item.id, quantity=1)
+    test_db.add_all([order_item1, order_item2])
+    test_db.commit()
+
+    # Fetch each order individually
+    for order in [order1, order2]:
+        response = customer_client.get(f"/orders/{order.id}")
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert response_json["id"] == order.id
+        assert response_json["user_id"] == 1
+        assert len(response_json["items"]) == 1
+        assert response_json["items"][0]["menu_item_id"] == menu_item.id
+        assert response_json["items"][0]["quantity"] == 1


### PR DESCRIPTION
Previously, order items were incorrectly mapped to menu items. You could call successfully call the "Get Orders" API while the orders were empty, but once an order had been created, subsequent calls to that API would fail. Similarly, valid requests to the "Get Order" API would fail due to the incorrect mapping. 

This update ensures that orders can be correctly created (including with multiple order items) and then retrieved with the "Get Orders" and "Get Order" APIs.