### PR TITLE
Update HALL_OF_FAME.md

### DIFF
--- a/HALL_OF_FAME.md
+++ b/HALL_OF_FAME.md
@@ -16,7 +16,7 @@ The following is a list of users who have completed all current challenges in th
 | ------ | -------- | --------- | --------- |
 | <img src="https://avatars.githubusercontent.com/u/52045281?s=400&u=f77f6039401295b5bf0f47b103eda021ade270d4&v=4" width="100px"> | [turbra](https://github.com/turbra/Damn-Vulnerable-RESTaurant-API-Game) | Root Access | [solution url](https://github.com/turbra/DV-RESTaurant-API-Game-Solution/blob/main/README.md) |
 | <img src="https://avatars.githubusercontent.com/u/104169244?v=4" width="100px">                                                 | [GangGreenTemperTatum](https://github.com/GangGreenTemperTatum/Damn-Vulnerable-RESTaurant-API-Game) | Root Access & Fixed All Vulns | [solution url](https://github.com/GangGreenTemperTatum/Damn-Vulnerable-RESTaurant-API-Game/blob/main/walkthrough/Damn-Vulnerable-RESTaurant-API-Game%20CTF%20Web%20Applic%20f4cc903ddcbf49cb93a7ebe710af7837.md) |
-
+| <img src="https://avatars.githubusercontent.com/u/29945379?v=4" width="100px"> | [HannoZ](https://github.com/HannoZ/Damn-Vulnerable-RESTaurant-API-Game) | Fixed All Vulns | [solution url](https://github.com/HannoZ/Damn-Vulnerable-RESTaurant-API-Game/blob/main/vulnerability-fixes.md) |
 ---
 
 ## Submitting Your Solution


### PR DESCRIPTION
Adding myself to the hall of fame after fixing the vulnerabilities :) 
An overview of the fixes can be found [here](https://github.com/HannoZ/Damn-Vulnerable-RESTaurant-API-Game/blob/main/vulnerability-fixes.md)

One suggestion that could make the challenges more fun is to move the hints to a separate location (eg. hints.md that you can check if you get stuck). Now for most challenges it is immediately clear where the fix needs to be applied